### PR TITLE
RFC: allow nil payload when encoding

### DIFF
--- a/src/mqtt/encoding_utils.clj
+++ b/src/mqtt/encoding_utils.clj
@@ -40,7 +40,13 @@
   (encode-bytes [bs ^ByteBuf out]
     (.writeBytes out ^bytes bs))
   (remaining-bytes [bs]
-    (count bs)))
+    (count bs))
+
+  nil
+  (encode-bytes [_ ^ByteBuf out]
+    out)
+  (remaining-bytes [_]
+    0))
 
 (defn encode-unsigned-short
   "Encode an unsigned short"

--- a/src/mqtt/packets/publish.clj
+++ b/src/mqtt/packets/publish.clj
@@ -34,7 +34,6 @@
 (defmethod validate-message :publish
   [{:keys [topic payload qos message-id]}]
   (if (string/blank? topic)                 (throw (EncoderException.)))
-  (if (nil? payload)                        (throw (EncoderException.)))
   (validate-message-id qos message-id))
 
 (defmethod remaining-length :publish

--- a/test/mqtt/packets/publish_test.clj
+++ b/test/mqtt/packets/publish_test.clj
@@ -169,10 +169,6 @@
     (is (thrown? EncoderException (validate-message {:type :publish
                                                      :payload "ohai"}))))
 
-  (testing "it throws for missing payload"
-    (is (thrown? EncoderException (validate-message {:type :publish
-                                                     :topic "test"}))))
-
   (testing "it throws if qos > 0 and no message-id"
     (is (thrown? EncoderException (validate-message {:type :publish
                                                      :qos 1
@@ -202,6 +198,20 @@
                         0x00 0x04 "test"
                         ;; payload
                         "hello world"))))))
+
+  (testing "when encoding a publish packet with no payload"
+    (let [encoder (make-encoder)
+          packet  {:type :publish :topic "test"}
+          out     (Unpooled/buffer 8)]
+      (.encode encoder nil packet out)
+      (is (= (byte-buffer-to-bytes out)
+             (into [] (bytes-to-byte-array
+                        ;; fixed header
+                        0x30
+                        ;; remaining length
+                        0x06
+                        ;; topic
+                        0x00 0x04 "test"))))))
 
   (testing "when encoding a publish packets with other types of payloads"
     (doseq [[container  payload] {"string" "hello world"


### PR DESCRIPTION
When encoding a payload, allow nil, as an empty payload. Allows running `(remaining-bytes nil) ;; => 0`.
